### PR TITLE
Typos in the vignettes 

### DIFF
--- a/vignettes/dodgr.Rmd
+++ b/vignettes/dodgr.Rmd
@@ -219,7 +219,7 @@ head (graph)
 ```
 Note that the actual graph contains around 30 times as many edges as there are
 streets, indicating that each street is composed on average of around 30
-individual segments.  The individual points points or vertices from those
+individual segments.  The individual points or vertices from those
 segments can be extracted with,
 ```{r hampi-verts}
 vt <- dodgr_vertices (graph)

--- a/vignettes/dodgr.Rmd
+++ b/vignettes/dodgr.Rmd
@@ -165,8 +165,7 @@ million shortest-path distances, all in under 30 seconds.
 # 3 Graphs and Street Networks
 
 Although the above code is short and fast, most users will probably want more
-control over their graphs and routing possibilities. Each of the steps indicated
-above (through the `quiet = FALSE` option) can be implemented separately. To
+control over their graphs and routing possibilities. To
 illustrate, the remainder of this vignette analyses the much smaller street
 network of Hampi, Karnataka, India, included in the `dodgr` package as the
 dataset [`hampi`](https://atfutures.github.io/dodgr/reference/hampi.html). This


### PR DESCRIPTION
Hi! There were some unimportant typos in the vignettes and I changed them. Moreover there are a few things that I would change but I'm not sure your are ok with it. 

1) IMHO the explanation of  `dodgr_distances()` function with only the `from` parameter is wrong (not updated probably) since you write: "If only from is provided, a square matrix is returned of pair-wise distances between all listed points." but this is not true, right? You return a matrix of n (number of from-points) times m (number of vertices). 
2) Sometimes to select one or more columns in a df you do:

``` {r}
cols <- c("A", "B")
df[, names(df) %in% cols]
```
but, in my opinion, 
```{r}
df[, cols]
```
is much simple and more clear. 

I can provide new commits to change these two points if you want. 

