### PR TITLE
Use `expect_no_message()` over `expect_silent()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     rmarkdown,
     roxygen2,
     sf,
-    testthat,
+    testthat (>= 3.1.6),
     tidygraph
 LinkingTo:
     Rcpp,

--- a/tests/testthat/test-iso.R
+++ b/tests/testthat/test-iso.R
@@ -14,7 +14,7 @@ test_that ("isodists", {
     # This all exists just to test the next line:
     requireNamespace ("geodist")
     requireNamespace ("dplyr")
-    expect_silent (net <- weight_streetnet (hsc,
+    expect_no_message (net <- weight_streetnet (hsc,
         wt_profile = "bicycle"
     ))
     npts <- 100


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, we need to work around a broken test of yours that was expecting no output. I've done that by swapping `expect_silent()` for `expect_no_message()`, which I'm guessing is what you were trying to avoid.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!