### PR TITLE
Strong components

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,12 +8,16 @@ Authors@R: c(
     person("Robin", "Lovelace", role = "ctb"),
     person("Andrew", "Smith", role = "ctb"),
     person("Malcolm", "Morgan", role = "ctb"),
-    person("Andrea", "Gilardi", role="ctb", comment = c(ORCID = "0000-0002-9424-7439")),
-    person("Eduardo", "Leoni", role="ctb", comment = c(ORCID = "0000-0003-0955-5232")),
+    person("Andrea", "Gilardi", role = "ctb",
+           comment = c(ORCID = "0000-0002-9424-7439")),
+    person("Eduardo", "Leoni", role = "ctb",
+           comment = c(ORCID = "0000-0003-0955-5232")),
     person("Shane", "Saunders", role = "cph",
            comment = "Original author of included code for priority heaps"),
     person("Stanislaw", "Adaszewski", role = "cph",
-           comment = "author of include concaveman-cpp code") 
+           comment = "author of include concaveman-cpp code"),
+    person("Harry", "Roberts", , "ts22hr@leeds.ac.uk", role = "ctb",
+           comment = c(ORCID = "0009-0005-5443-0684"))
   )
 Description: Distances on dual-weighted directed graphs using
     priority-queue shortest paths (Padgham (2019) <doi:10.32866/6945>).
@@ -63,5 +67,5 @@ Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: GNU make

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Fix bug with categorical distances that neglected edges through compound junctions (#305)
 - Fix bug in duplicating bi-directional edges in weighted sc-class graphs
 - Added support for strong components in `dodgr_components()` (#322)
+- Added Harry Roberts as a contributor
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Add `pairwise` parameter to `dodgr_times()`; thanks to @leoniedu (#314)
 - Fix bug with categorical distances that neglected edges through compound junctions (#305)
 - Fix bug in duplicating bi-directional edges in weighted sc-class graphs
+- Added support for strong components in `dodgr_components()` (#322)
 
 ---
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -6,14 +6,14 @@
 #' sample is used to estimate timing, by calculating centrality from just a few
 #' vertices.
 #' @noRd
-rcpp_centrality <- function (graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample) {
-    .Call (`_dodgr_rcpp_centrality`, graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample)
+rcpp_centrality <- function(graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample) {
+    .Call(`_dodgr_rcpp_centrality`, graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample)
 }
 
 #' rcpp_concaveman
-#' @noRd
-rcpp_concaveman <- function (xy, hull_in, concavity, length_threshold) {
-    .Call (`_dodgr_rcpp_concaveman`, xy, hull_in, concavity, length_threshold)
+#' @noRd 
+rcpp_concaveman <- function(xy, hull_in, concavity, length_threshold) {
+    .Call(`_dodgr_rcpp_concaveman`, xy, hull_in, concavity, length_threshold)
 }
 
 #' De-duplicate edges by replacing with minimal weighted distances and times
@@ -28,8 +28,8 @@ rcpp_concaveman <- function (xy, hull_in, concavity, length_threshold) {
 #' minimal value taken from all duplicated edges. If 't_col' is specified, the
 #' equivalent minimal times are in the lower half of the result.
 #' @noRd
-rcpp_deduplicate <- function (graph, fr_col, to_col, d_col, t_col) {
-    .Call (`_dodgr_rcpp_deduplicate`, graph, fr_col, to_col, d_col, t_col)
+rcpp_deduplicate <- function(graph, fr_col, to_col, d_col, t_col) {
+    .Call(`_dodgr_rcpp_deduplicate`, graph, fr_col, to_col, d_col, t_col)
 }
 
 #' Make unordered_set of all new edge names
@@ -64,8 +64,8 @@ NULL
 #' @return Rcpp::List object of `sf::LINESTRING` geoms
 #'
 #' @noRd
-rcpp_aggregate_to_sf <- function (graph_full, graph_contr, edge_map) {
-    .Call (`_dodgr_rcpp_aggregate_to_sf`, graph_full, graph_contr, edge_map)
+rcpp_aggregate_to_sf <- function(graph_full, graph_contr, edge_map) {
+    .Call(`_dodgr_rcpp_aggregate_to_sf`, graph_full, graph_contr, edge_map)
 }
 
 #' rcpp_flows_aggregate_par
@@ -86,8 +86,8 @@ rcpp_aggregate_to_sf <- function (graph_full, graph_contr, edge_map) {
 #' characters long, that chance should be 1 / 62 ^ 10.
 #'
 #' @noRd
-rcpp_flows_aggregate_par <- function (graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_aggregate_par`, graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type)
+rcpp_flows_aggregate_par <- function(graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_aggregate_par`, graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type)
 }
 
 #' rcpp_flows_aggregate_pairwise
@@ -110,8 +110,8 @@ rcpp_flows_aggregate_par <- function (graph, vert_map_in, fromi, toi_in, flows, 
 #' characters long, that chance should be 1 / 62 ^ 10.
 #'
 #' @noRd
-rcpp_flows_aggregate_pairwise <- function (graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_aggregate_pairwise`, graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type)
+rcpp_flows_aggregate_pairwise <- function(graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_aggregate_pairwise`, graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type)
 }
 
 #' rcpp_flows_disperse_par
@@ -132,8 +132,8 @@ rcpp_flows_aggregate_pairwise <- function (graph, vert_map_in, fromi, toi, flows
 #' between each pair of from and to points.
 #'
 #' @noRd
-rcpp_flows_disperse_par <- function (graph, vert_map_in, fromi, k, dens, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_disperse_par`, graph, vert_map_in, fromi, k, dens, tol, heap_type)
+rcpp_flows_disperse_par <- function(graph, vert_map_in, fromi, k, dens, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_disperse_par`, graph, vert_map_in, fromi, k, dens, tol, heap_type)
 }
 
 #' rcpp_flows_si
@@ -149,13 +149,13 @@ rcpp_flows_disperse_par <- function (graph, vert_map_in, fromi, k, dens, tol, he
 #' (to-vertices) are not considered.
 #'
 #' @noRd
-rcpp_flows_si <- function (graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_si`, graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type)
+rcpp_flows_si <- function(graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_si`, graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type)
 }
 
 #' @noRd
-rcpp_fundamental_cycles <- function (graph, verts) {
-    .Call (`_dodgr_rcpp_fundamental_cycles`, graph, verts)
+rcpp_fundamental_cycles <- function(graph, verts) {
+    .Call(`_dodgr_rcpp_fundamental_cycles`, graph, verts)
 }
 
 #' get_to_from
@@ -170,7 +170,7 @@ NULL
 #' same_hwy_type
 #'
 #' Determine whether two edges represent the same weight category (type of
-#' highway for street networks, for example). Categories are not retained in
+#' highway for street networks, for example). Categories are not retained in 
 #' converted graphs, but can be discerned by comparing ratios of weighted to
 #' non-weighted distances.
 #' @noRd
@@ -188,8 +188,8 @@ NULL
 #' original and contracted graph.
 #'
 #' @noRd
-rcpp_contract_graph <- function (graph, vertlist_in) {
-    .Call (`_dodgr_rcpp_contract_graph`, graph, vertlist_in)
+rcpp_contract_graph <- function(graph, vertlist_in) {
+    .Call(`_dodgr_rcpp_contract_graph`, graph, vertlist_in)
 }
 
 #' rcpp_merge_cols
@@ -203,8 +203,8 @@ rcpp_contract_graph <- function (graph, vertlist_in) {
 #' those edges to be retained in the directed graph.
 #'
 #' @noRd
-rcpp_merge_cols <- function (graph) {
-    .Call (`_dodgr_rcpp_merge_cols`, graph)
+rcpp_merge_cols <- function(graph) {
+    .Call(`_dodgr_rcpp_merge_cols`, graph)
 }
 
 #' sample_one_edge_no_comps
@@ -213,7 +213,7 @@ rcpp_merge_cols <- function (graph) {
 #' in \code{sample_one_vertex}
 #'
 #' @param edge_map edge_map
-#' @return std::vector of 2 elements: [0] with value of largest connected
+#' @return std::vector of 2 elements: [0] with value of largest connected 
 #' component; [1] with random index to one edge that is part of that component.
 #' @noRd
 NULL
@@ -240,8 +240,8 @@ NULL
 #' @return Smaller sub-set of \code{graph}
 #'
 #' @noRd
-rcpp_sample_graph <- function (graph, nverts_to_sample) {
-    .Call (`_dodgr_rcpp_sample_graph`, graph, nverts_to_sample)
+rcpp_sample_graph <- function(graph, nverts_to_sample) {
+    .Call(`_dodgr_rcpp_sample_graph`, graph, nverts_to_sample)
 }
 
 #' graph_has_components
@@ -253,7 +253,7 @@ NULL
 
 #' @name graph_from_df
 #'
-#' Convert a standard graph data.frame into an object of class graph. Graphs
+#' Convert a standard graph data.frame into an object of class graph. Graphs 
 #' are standardised with the function \code{dodgr_convert_graph()$graph}, and
 #' contain only the four columns [from, to, d, w]
 #'
@@ -263,7 +263,35 @@ NULL
 #' identify_graph_components
 #'
 #' Identify initial graph components for each **vertex**
-#' Identification for edges is subsequently perrformed with
+#' Identification for edges is subsequently performed with 
+#' \code{rcpp_get_component_vector}.
+#'
+#' @param v unordered_map <vertex_id_t, vertex_t>
+#' @param com component map from each vertex to component numbers
+#' @noRd
+NULL
+
+#' strong_connect
+#'
+#' Helper function for applying Tarjan's algroithm to identify
+#' strong components recursively
+#'
+#' @param vt id of vertex currently being evaluated
+#' @param v unordered_map <vertex_id_t, vertex_t>
+#' @param com component map from each vertex to component numbers
+#' @param index_map map from each vertex to index number
+#' @param lowlink_map map from each vertex to lowlink number
+#' @param on_stack set of all vertices currently on stack
+#' @param s stack used to execute algorithm
+#' @param index used to execute algoritm
+#' @param compnum the current component number
+#' @noRd
+NULL
+
+#' identify_graph_strong_components
+#'
+#' Identify initial graph strong components for each **vertex**
+#' Identification for edges is subsequently performed with 
 #' \code{rcpp_get_component_vector}.
 #'
 #' @param v unordered_map <vertex_id_t, vertex_t>
@@ -278,11 +306,14 @@ NULL
 #' @param graph graph to be processed; stripped down and standardised to five
 #' columns
 #'
+#' @param strong A Boolean flag to indicate whether components should be strong,
+#' i.e. its vertices connected bidirectionally. Defaults to FALSE.
+#'
 #' @return Two vectors: one of edge IDs and one of corresponding component
 #' numbers
 #' @noRd
-rcpp_get_component_vector <- function (graph) {
-    .Call (`_dodgr_rcpp_get_component_vector`, graph)
+rcpp_get_component_vector <- function(graph, strong = FALSE) {
+    .Call(`_dodgr_rcpp_get_component_vector`, graph, strong)
 }
 
 #' rcpp_unique_rownames
@@ -291,8 +322,8 @@ rcpp_get_component_vector <- function (graph) {
 #' rounded to <precision>. Used when vertices have no ID values.
 #'
 #' @noRd
-rcpp_unique_rownames <- function (xyfrom, xyto, precision = 10L) {
-    .Call (`_dodgr_rcpp_unique_rownames`, xyfrom, xyto, precision)
+rcpp_unique_rownames <- function(xyfrom, xyto, precision = 10L) {
+    .Call(`_dodgr_rcpp_unique_rownames`, xyfrom, xyto, precision)
 }
 
 #' Determine which side of intersecting line a point lies on.
@@ -325,8 +356,8 @@ NULL
 #' @return 0-indexed Rcpp::NumericVector index into graph of nearest points
 #'
 #' @noRd
-rcpp_points_index_par <- function (xy, pts) {
-    .Call (`_dodgr_rcpp_points_index_par`, xy, pts)
+rcpp_points_index_par <- function(xy, pts) {
+    .Call(`_dodgr_rcpp_points_index_par`, xy, pts)
 }
 
 #' rcpp_points_to_edges_par
@@ -339,43 +370,43 @@ rcpp_points_index_par <- function (xy, pts) {
 #' @return 0-indexed Rcpp::NumericVector index into graph of nearest points
 #'
 #' @noRd
-rcpp_points_to_edges_par <- function (graph, pts) {
-    .Call (`_dodgr_rcpp_points_to_edges_par`, graph, pts)
+rcpp_points_to_edges_par <- function(graph, pts) {
+    .Call(`_dodgr_rcpp_points_to_edges_par`, graph, pts)
 }
 
 #' rcpp_get_sp_dists_par
 #'
 #' @noRd
-rcpp_get_sp_dists_par <- function (graph, vert_map_in, fromi, toi_in, heap_type, is_spatial) {
-    .Call (`_dodgr_rcpp_get_sp_dists_par`, graph, vert_map_in, fromi, toi_in, heap_type, is_spatial)
+rcpp_get_sp_dists_par <- function(graph, vert_map_in, fromi, toi_in, heap_type, is_spatial) {
+    .Call(`_dodgr_rcpp_get_sp_dists_par`, graph, vert_map_in, fromi, toi_in, heap_type, is_spatial)
 }
 
 #' rcpp_get_sp_dists_nearest
 #'
 #' @noRd
-rcpp_get_sp_dists_nearest <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists_nearest`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists_nearest <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_sp_dists_nearest`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_paired_par
 #'
 #' @noRd
-rcpp_get_sp_dists_paired_par <- function (graph, vert_map_in, fromi, toi, heap_type, is_spatial) {
-    .Call (`_dodgr_rcpp_get_sp_dists_paired_par`, graph, vert_map_in, fromi, toi, heap_type, is_spatial)
+rcpp_get_sp_dists_paired_par <- function(graph, vert_map_in, fromi, toi, heap_type, is_spatial) {
+    .Call(`_dodgr_rcpp_get_sp_dists_paired_par`, graph, vert_map_in, fromi, toi, heap_type, is_spatial)
 }
 
 #' rcpp_get_iso
 #'
 #' @noRd
-rcpp_get_iso <- function (graph, vert_map_in, fromi, dlim, heap_type) {
-    .Call (`_dodgr_rcpp_get_iso`, graph, vert_map_in, fromi, dlim, heap_type)
+rcpp_get_iso <- function(graph, vert_map_in, fromi, dlim, heap_type) {
+    .Call(`_dodgr_rcpp_get_iso`, graph, vert_map_in, fromi, dlim, heap_type)
 }
 
 #' rcpp_get_sp_dists
 #'
 #' @noRd
-rcpp_get_sp_dists <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_sp_dists`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_paths
@@ -396,12 +427,12 @@ rcpp_get_sp_dists <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
 #' @note Returns 1-indexed values indexing directly into the R input
 #'
 #' @noRd
-rcpp_get_paths <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_paths`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_paths <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_paths`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
-rcpp_get_paths_pairwise <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_paths_pairwise`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_paths_pairwise <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_paths_pairwise`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_categorical
@@ -413,21 +444,21 @@ rcpp_get_paths_pairwise <- function (graph, vert_map_in, fromi, toi_in, heap_typ
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_categorical <- function (graph, vert_map_in, fromi, toi_in, heap_type, proportions_only) {
-    .Call (`_dodgr_rcpp_get_sp_dists_categorical`, graph, vert_map_in, fromi, toi_in, heap_type, proportions_only)
+rcpp_get_sp_dists_categorical <- function(graph, vert_map_in, fromi, toi_in, heap_type, proportions_only) {
+    .Call(`_dodgr_rcpp_get_sp_dists_categorical`, graph, vert_map_in, fromi, toi_in, heap_type, proportions_only)
 }
 
 #' rcpp_get_sp_dists_categ_paired
 #'
 #' Pairwise version of 'get_sp_dists_categorical'. The `graph` must have an
-#' `edge_type` column of non-negative integers, with 0 denoting edges which are
+#'`edge_type` column of non-negative integers, with 0 denoting edges which are
 #' not aggregated, and all other values defining aggregation categories.
 #'
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_categ_paired <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists_categ_paired`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists_categ_paired <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_sp_dists_categ_paired`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_cat_threshold
@@ -439,8 +470,8 @@ rcpp_get_sp_dists_categ_paired <- function (graph, vert_map_in, fromi, toi_in, h
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_cat_threshold <- function (graph, vert_map_in, fromi, dlimit, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists_cat_threshold`, graph, vert_map_in, fromi, dlimit, heap_type)
+rcpp_get_sp_dists_cat_threshold <- function(graph, vert_map_in, fromi, dlimit, heap_type) {
+    .Call(`_dodgr_rcpp_get_sp_dists_cat_threshold`, graph, vert_map_in, fromi, dlimit, heap_type)
 }
 
 #' rcpp_gen_hash
@@ -448,8 +479,8 @@ rcpp_get_sp_dists_cat_threshold <- function (graph, vert_map_in, fromi, dlimit, 
 #' Efficient generation of long sequences of hash keys
 #'
 #' @noRd
-rcpp_gen_hash <- function (n, hash_len) {
-    .Call (`_dodgr_rcpp_gen_hash`, n, hash_len)
+rcpp_gen_hash <- function(n, hash_len) {
+    .Call(`_dodgr_rcpp_gen_hash`, n, hash_len)
 }
 
 #' rcpp_sf_as_network
@@ -475,13 +506,14 @@ rcpp_gen_hash <- function (n, hash_len) {
 #' 4. OSM way ID
 #'
 #' @noRd
-rcpp_sf_as_network <- function (sf_lines, pr) {
-    .Call (`_dodgr_rcpp_sf_as_network`, sf_lines, pr)
+rcpp_sf_as_network <- function(sf_lines, pr) {
+    .Call(`_dodgr_rcpp_sf_as_network`, sf_lines, pr)
 }
 
 #' rcpp_route_times
 #'
 #' @noRd
-rcpp_route_times <- function (graph, left_side, turn_penalty) {
-    .Call (`_dodgr_rcpp_route_times`, graph, left_side, turn_penalty)
+rcpp_route_times <- function(graph, left_side, turn_penalty) {
+    .Call(`_dodgr_rcpp_route_times`, graph, left_side, turn_penalty)
 }
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -6,14 +6,14 @@
 #' sample is used to estimate timing, by calculating centrality from just a few
 #' vertices.
 #' @noRd
-rcpp_centrality <- function(graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample) {
-    .Call(`_dodgr_rcpp_centrality`, graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample)
+rcpp_centrality <- function (graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample) {
+    .Call (`_dodgr_rcpp_centrality`, graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample)
 }
 
 #' rcpp_concaveman
-#' @noRd 
-rcpp_concaveman <- function(xy, hull_in, concavity, length_threshold) {
-    .Call(`_dodgr_rcpp_concaveman`, xy, hull_in, concavity, length_threshold)
+#' @noRd
+rcpp_concaveman <- function (xy, hull_in, concavity, length_threshold) {
+    .Call (`_dodgr_rcpp_concaveman`, xy, hull_in, concavity, length_threshold)
 }
 
 #' De-duplicate edges by replacing with minimal weighted distances and times
@@ -28,8 +28,8 @@ rcpp_concaveman <- function(xy, hull_in, concavity, length_threshold) {
 #' minimal value taken from all duplicated edges. If 't_col' is specified, the
 #' equivalent minimal times are in the lower half of the result.
 #' @noRd
-rcpp_deduplicate <- function(graph, fr_col, to_col, d_col, t_col) {
-    .Call(`_dodgr_rcpp_deduplicate`, graph, fr_col, to_col, d_col, t_col)
+rcpp_deduplicate <- function (graph, fr_col, to_col, d_col, t_col) {
+    .Call (`_dodgr_rcpp_deduplicate`, graph, fr_col, to_col, d_col, t_col)
 }
 
 #' Make unordered_set of all new edge names
@@ -64,8 +64,8 @@ NULL
 #' @return Rcpp::List object of `sf::LINESTRING` geoms
 #'
 #' @noRd
-rcpp_aggregate_to_sf <- function(graph_full, graph_contr, edge_map) {
-    .Call(`_dodgr_rcpp_aggregate_to_sf`, graph_full, graph_contr, edge_map)
+rcpp_aggregate_to_sf <- function (graph_full, graph_contr, edge_map) {
+    .Call (`_dodgr_rcpp_aggregate_to_sf`, graph_full, graph_contr, edge_map)
 }
 
 #' rcpp_flows_aggregate_par
@@ -86,8 +86,8 @@ rcpp_aggregate_to_sf <- function(graph_full, graph_contr, edge_map) {
 #' characters long, that chance should be 1 / 62 ^ 10.
 #'
 #' @noRd
-rcpp_flows_aggregate_par <- function(graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type) {
-    .Call(`_dodgr_rcpp_flows_aggregate_par`, graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type)
+rcpp_flows_aggregate_par <- function (graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type) {
+    .Call (`_dodgr_rcpp_flows_aggregate_par`, graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type)
 }
 
 #' rcpp_flows_aggregate_pairwise
@@ -110,8 +110,8 @@ rcpp_flows_aggregate_par <- function(graph, vert_map_in, fromi, toi_in, flows, n
 #' characters long, that chance should be 1 / 62 ^ 10.
 #'
 #' @noRd
-rcpp_flows_aggregate_pairwise <- function(graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type) {
-    .Call(`_dodgr_rcpp_flows_aggregate_pairwise`, graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type)
+rcpp_flows_aggregate_pairwise <- function (graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type) {
+    .Call (`_dodgr_rcpp_flows_aggregate_pairwise`, graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type)
 }
 
 #' rcpp_flows_disperse_par
@@ -132,8 +132,8 @@ rcpp_flows_aggregate_pairwise <- function(graph, vert_map_in, fromi, toi, flows,
 #' between each pair of from and to points.
 #'
 #' @noRd
-rcpp_flows_disperse_par <- function(graph, vert_map_in, fromi, k, dens, tol, heap_type) {
-    .Call(`_dodgr_rcpp_flows_disperse_par`, graph, vert_map_in, fromi, k, dens, tol, heap_type)
+rcpp_flows_disperse_par <- function (graph, vert_map_in, fromi, k, dens, tol, heap_type) {
+    .Call (`_dodgr_rcpp_flows_disperse_par`, graph, vert_map_in, fromi, k, dens, tol, heap_type)
 }
 
 #' rcpp_flows_si
@@ -149,13 +149,13 @@ rcpp_flows_disperse_par <- function(graph, vert_map_in, fromi, k, dens, tol, hea
 #' (to-vertices) are not considered.
 #'
 #' @noRd
-rcpp_flows_si <- function(graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type) {
-    .Call(`_dodgr_rcpp_flows_si`, graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type)
+rcpp_flows_si <- function (graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type) {
+    .Call (`_dodgr_rcpp_flows_si`, graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type)
 }
 
 #' @noRd
-rcpp_fundamental_cycles <- function(graph, verts) {
-    .Call(`_dodgr_rcpp_fundamental_cycles`, graph, verts)
+rcpp_fundamental_cycles <- function (graph, verts) {
+    .Call (`_dodgr_rcpp_fundamental_cycles`, graph, verts)
 }
 
 #' get_to_from
@@ -170,7 +170,7 @@ NULL
 #' same_hwy_type
 #'
 #' Determine whether two edges represent the same weight category (type of
-#' highway for street networks, for example). Categories are not retained in 
+#' highway for street networks, for example). Categories are not retained in
 #' converted graphs, but can be discerned by comparing ratios of weighted to
 #' non-weighted distances.
 #' @noRd
@@ -188,8 +188,8 @@ NULL
 #' original and contracted graph.
 #'
 #' @noRd
-rcpp_contract_graph <- function(graph, vertlist_in) {
-    .Call(`_dodgr_rcpp_contract_graph`, graph, vertlist_in)
+rcpp_contract_graph <- function (graph, vertlist_in) {
+    .Call (`_dodgr_rcpp_contract_graph`, graph, vertlist_in)
 }
 
 #' rcpp_merge_cols
@@ -203,8 +203,8 @@ rcpp_contract_graph <- function(graph, vertlist_in) {
 #' those edges to be retained in the directed graph.
 #'
 #' @noRd
-rcpp_merge_cols <- function(graph) {
-    .Call(`_dodgr_rcpp_merge_cols`, graph)
+rcpp_merge_cols <- function (graph) {
+    .Call (`_dodgr_rcpp_merge_cols`, graph)
 }
 
 #' sample_one_edge_no_comps
@@ -240,8 +240,8 @@ NULL
 #' @return Smaller sub-set of \code{graph}
 #'
 #' @noRd
-rcpp_sample_graph <- function(graph, nverts_to_sample) {
-    .Call(`_dodgr_rcpp_sample_graph`, graph, nverts_to_sample)
+rcpp_sample_graph <- function (graph, nverts_to_sample) {
+    .Call (`_dodgr_rcpp_sample_graph`, graph, nverts_to_sample)
 }
 
 #' graph_has_components
@@ -253,7 +253,7 @@ NULL
 
 #' @name graph_from_df
 #'
-#' Convert a standard graph data.frame into an object of class graph. Graphs 
+#' Convert a standard graph data.frame into an object of class graph. Graphs
 #' are standardised with the function \code{dodgr_convert_graph()$graph}, and
 #' contain only the four columns [from, to, d, w]
 #'
@@ -312,8 +312,8 @@ NULL
 #' @return Two vectors: one of edge IDs and one of corresponding component
 #' numbers
 #' @noRd
-rcpp_get_component_vector <- function(graph, strong = FALSE) {
-    .Call(`_dodgr_rcpp_get_component_vector`, graph, strong)
+rcpp_get_component_vector <- function (graph, strong = FALSE) {
+    .Call (`_dodgr_rcpp_get_component_vector`, graph, strong)
 }
 
 #' rcpp_unique_rownames
@@ -322,8 +322,8 @@ rcpp_get_component_vector <- function(graph, strong = FALSE) {
 #' rounded to <precision>. Used when vertices have no ID values.
 #'
 #' @noRd
-rcpp_unique_rownames <- function(xyfrom, xyto, precision = 10L) {
-    .Call(`_dodgr_rcpp_unique_rownames`, xyfrom, xyto, precision)
+rcpp_unique_rownames <- function (xyfrom, xyto, precision = 10L) {
+    .Call (`_dodgr_rcpp_unique_rownames`, xyfrom, xyto, precision)
 }
 
 #' Determine which side of intersecting line a point lies on.
@@ -356,8 +356,8 @@ NULL
 #' @return 0-indexed Rcpp::NumericVector index into graph of nearest points
 #'
 #' @noRd
-rcpp_points_index_par <- function(xy, pts) {
-    .Call(`_dodgr_rcpp_points_index_par`, xy, pts)
+rcpp_points_index_par <- function (xy, pts) {
+    .Call (`_dodgr_rcpp_points_index_par`, xy, pts)
 }
 
 #' rcpp_points_to_edges_par
@@ -370,43 +370,43 @@ rcpp_points_index_par <- function(xy, pts) {
 #' @return 0-indexed Rcpp::NumericVector index into graph of nearest points
 #'
 #' @noRd
-rcpp_points_to_edges_par <- function(graph, pts) {
-    .Call(`_dodgr_rcpp_points_to_edges_par`, graph, pts)
+rcpp_points_to_edges_par <- function (graph, pts) {
+    .Call (`_dodgr_rcpp_points_to_edges_par`, graph, pts)
 }
 
 #' rcpp_get_sp_dists_par
 #'
 #' @noRd
-rcpp_get_sp_dists_par <- function(graph, vert_map_in, fromi, toi_in, heap_type, is_spatial) {
-    .Call(`_dodgr_rcpp_get_sp_dists_par`, graph, vert_map_in, fromi, toi_in, heap_type, is_spatial)
+rcpp_get_sp_dists_par <- function (graph, vert_map_in, fromi, toi_in, heap_type, is_spatial) {
+    .Call (`_dodgr_rcpp_get_sp_dists_par`, graph, vert_map_in, fromi, toi_in, heap_type, is_spatial)
 }
 
 #' rcpp_get_sp_dists_nearest
 #'
 #' @noRd
-rcpp_get_sp_dists_nearest <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call(`_dodgr_rcpp_get_sp_dists_nearest`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists_nearest <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call (`_dodgr_rcpp_get_sp_dists_nearest`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_paired_par
 #'
 #' @noRd
-rcpp_get_sp_dists_paired_par <- function(graph, vert_map_in, fromi, toi, heap_type, is_spatial) {
-    .Call(`_dodgr_rcpp_get_sp_dists_paired_par`, graph, vert_map_in, fromi, toi, heap_type, is_spatial)
+rcpp_get_sp_dists_paired_par <- function (graph, vert_map_in, fromi, toi, heap_type, is_spatial) {
+    .Call (`_dodgr_rcpp_get_sp_dists_paired_par`, graph, vert_map_in, fromi, toi, heap_type, is_spatial)
 }
 
 #' rcpp_get_iso
 #'
 #' @noRd
-rcpp_get_iso <- function(graph, vert_map_in, fromi, dlim, heap_type) {
-    .Call(`_dodgr_rcpp_get_iso`, graph, vert_map_in, fromi, dlim, heap_type)
+rcpp_get_iso <- function (graph, vert_map_in, fromi, dlim, heap_type) {
+    .Call (`_dodgr_rcpp_get_iso`, graph, vert_map_in, fromi, dlim, heap_type)
 }
 
 #' rcpp_get_sp_dists
 #'
 #' @noRd
-rcpp_get_sp_dists <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call(`_dodgr_rcpp_get_sp_dists`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call (`_dodgr_rcpp_get_sp_dists`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_paths
@@ -427,12 +427,12 @@ rcpp_get_sp_dists <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
 #' @note Returns 1-indexed values indexing directly into the R input
 #'
 #' @noRd
-rcpp_get_paths <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call(`_dodgr_rcpp_get_paths`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_paths <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call (`_dodgr_rcpp_get_paths`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
-rcpp_get_paths_pairwise <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call(`_dodgr_rcpp_get_paths_pairwise`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_paths_pairwise <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call (`_dodgr_rcpp_get_paths_pairwise`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_categorical
@@ -444,21 +444,21 @@ rcpp_get_paths_pairwise <- function(graph, vert_map_in, fromi, toi_in, heap_type
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_categorical <- function(graph, vert_map_in, fromi, toi_in, heap_type, proportions_only) {
-    .Call(`_dodgr_rcpp_get_sp_dists_categorical`, graph, vert_map_in, fromi, toi_in, heap_type, proportions_only)
+rcpp_get_sp_dists_categorical <- function (graph, vert_map_in, fromi, toi_in, heap_type, proportions_only) {
+    .Call (`_dodgr_rcpp_get_sp_dists_categorical`, graph, vert_map_in, fromi, toi_in, heap_type, proportions_only)
 }
 
 #' rcpp_get_sp_dists_categ_paired
 #'
 #' Pairwise version of 'get_sp_dists_categorical'. The `graph` must have an
-#'`edge_type` column of non-negative integers, with 0 denoting edges which are
+#' `edge_type` column of non-negative integers, with 0 denoting edges which are
 #' not aggregated, and all other values defining aggregation categories.
 #'
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_categ_paired <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call(`_dodgr_rcpp_get_sp_dists_categ_paired`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists_categ_paired <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call (`_dodgr_rcpp_get_sp_dists_categ_paired`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_cat_threshold
@@ -470,8 +470,8 @@ rcpp_get_sp_dists_categ_paired <- function(graph, vert_map_in, fromi, toi_in, he
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_cat_threshold <- function(graph, vert_map_in, fromi, dlimit, heap_type) {
-    .Call(`_dodgr_rcpp_get_sp_dists_cat_threshold`, graph, vert_map_in, fromi, dlimit, heap_type)
+rcpp_get_sp_dists_cat_threshold <- function (graph, vert_map_in, fromi, dlimit, heap_type) {
+    .Call (`_dodgr_rcpp_get_sp_dists_cat_threshold`, graph, vert_map_in, fromi, dlimit, heap_type)
 }
 
 #' rcpp_gen_hash
@@ -479,8 +479,8 @@ rcpp_get_sp_dists_cat_threshold <- function(graph, vert_map_in, fromi, dlimit, h
 #' Efficient generation of long sequences of hash keys
 #'
 #' @noRd
-rcpp_gen_hash <- function(n, hash_len) {
-    .Call(`_dodgr_rcpp_gen_hash`, n, hash_len)
+rcpp_gen_hash <- function (n, hash_len) {
+    .Call (`_dodgr_rcpp_gen_hash`, n, hash_len)
 }
 
 #' rcpp_sf_as_network
@@ -506,14 +506,13 @@ rcpp_gen_hash <- function(n, hash_len) {
 #' 4. OSM way ID
 #'
 #' @noRd
-rcpp_sf_as_network <- function(sf_lines, pr) {
-    .Call(`_dodgr_rcpp_sf_as_network`, sf_lines, pr)
+rcpp_sf_as_network <- function (sf_lines, pr) {
+    .Call (`_dodgr_rcpp_sf_as_network`, sf_lines, pr)
 }
 
 #' rcpp_route_times
 #'
 #' @noRd
-rcpp_route_times <- function(graph, left_side, turn_penalty) {
-    .Call(`_dodgr_rcpp_route_times`, graph, left_side, turn_penalty)
+rcpp_route_times <- function (graph, left_side, turn_penalty) {
+    .Call (`_dodgr_rcpp_route_times`, graph, left_side, turn_penalty)
 }
-

--- a/R/graph-functions.R
+++ b/R/graph-functions.R
@@ -310,6 +310,8 @@ dodgr_vertices_internal <- function (graph) {
 #' column to `data.frame`.
 #'
 #' @param graph A `data.frame` of edges
+#' @param strong A Boolean flag to indicate whether components should be strong,
+#' i.e. its vertices connected bidirectionally. Defaults to FALSE.
 #' @return Equivalent graph with additional `component` column,
 #' sequentially numbered from 1 = largest component.
 #' @family modification
@@ -317,7 +319,7 @@ dodgr_vertices_internal <- function (graph) {
 #' @examples
 #' graph <- weight_streetnet (hampi)
 #' graph <- dodgr_components (graph)
-dodgr_components <- function (graph) {
+dodgr_components <- function (graph, strong = FALSE) {
 
     graph <- tbl_to_df (graph)
 
@@ -329,15 +331,17 @@ dodgr_components <- function (graph) {
         if (is.na (gr_cols$edge_id)) {
             graph2$edge_id <- seq_len (nrow (graph2))
         }
-        cns <- rcpp_get_component_vector (graph2)
-
+        cns <- rcpp_get_component_vector (graph2,strong)
+        
         indx <- match (graph2$edge_id, cns$edge_id)
         component <- cns$edge_component [indx]
+        
+        # Handle where component numbers contain gaps using frequencies
         # Then re-number in order to decreasing component size:
-        graph$component <- match (
-            component,
-            order (table (component), decreasing = TRUE)
-        )
+        freqs <- table (component)
+        sorted_components <- names (freqs) [order (freqs, decreasing = TRUE)]
+        graph$component <- match (as.character (component), sorted_components)
+
     }
 
     return (graph)

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,20 +4,17 @@
   "identifier": "dodgr",
   "description": "Distances on dual-weighted directed graphs using priority-queue shortest paths (Padgham (2019) <doi:10.32866/6945>). Weighted directed graphs have weights from A to B which may differ from those from B to A. Dual-weighted directed graphs have two sets of such weights. A canonical example is a street network to be used for routing in which routes are calculated by weighting distances according to the type of way and mode of transport, yet lengths of routes must be calculated from direct distances.",
   "name": "dodgr: Distances on Directed Graphs",
-  "relatedLink": [
-    "https://UrbanAnalyst.github.io/dodgr/",
-    "https://CRAN.R-project.org/package=dodgr"
-  ],
+  "relatedLink": ["https://UrbanAnalyst.github.io/dodgr/", "https://CRAN.R-project.org/package=dodgr"],
   "codeRepository": "https://github.com/UrbanAnalyst/dodgr",
   "issueTracker": "https://github.com/UrbanAnalyst/dodgr/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.4.3.015",
+  "version": "0.4.3.15",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.5.1 (2025-06-13)",
+  "runtimePlatform": "R version 4.5.1 (2025-06-13 ucrt)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -69,6 +66,13 @@
       "givenName": "Eduardo",
       "familyName": "Leoni",
       "@id": "https://orcid.org/0000-0003-0955-5232"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Harry",
+      "familyName": "Roberts",
+      "email": "ts22hr@leeds.ac.uk",
+      "@id": "https://orcid.org/0009-0005-5443-0684"
     }
   ],
   "copyrightHolder": [
@@ -362,7 +366,7 @@
     },
     "SystemRequirements": "GNU make"
   },
-  "fileSize": "37019.613KB",
+  "fileSize": "72585.397KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",
@@ -381,10 +385,7 @@
         "@type": "PublicationIssue",
         "datePublished": "2019",
         "isPartOf": {
-          "@type": [
-            "PublicationVolume",
-            "Periodical"
-          ],
+          "@type": ["PublicationVolume", "Periodical"],
           "name": "Transport Findings"
         }
       }

--- a/man/dodgr_components.Rd
+++ b/man/dodgr_components.Rd
@@ -4,10 +4,13 @@
 \alias{dodgr_components}
 \title{Identify connected components of graph.}
 \usage{
-dodgr_components(graph)
+dodgr_components(graph, strong = FALSE)
 }
 \arguments{
 \item{graph}{A \code{data.frame} of edges}
+
+\item{strong}{A Boolean flag to indicate whether components should be strong,
+i.e. its vertices connected bidirectionally. Defaults to FALSE.}
 }
 \value{
 Equivalent graph with additional \code{component} column,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -190,13 +190,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_get_component_vector
-Rcpp::List rcpp_get_component_vector(const Rcpp::DataFrame& graph);
-RcppExport SEXP _dodgr_rcpp_get_component_vector(SEXP graphSEXP) {
+Rcpp::List rcpp_get_component_vector(const Rcpp::DataFrame& graph, bool strong);
+RcppExport SEXP _dodgr_rcpp_get_component_vector(SEXP graphSEXP, SEXP strongSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::DataFrame& >::type graph(graphSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_get_component_vector(graph));
+    Rcpp::traits::input_parameter< bool >::type strong(strongSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_get_component_vector(graph, strong));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -441,7 +442,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dodgr_rcpp_contract_graph", (DL_FUNC) &_dodgr_rcpp_contract_graph, 2},
     {"_dodgr_rcpp_merge_cols", (DL_FUNC) &_dodgr_rcpp_merge_cols, 1},
     {"_dodgr_rcpp_sample_graph", (DL_FUNC) &_dodgr_rcpp_sample_graph, 2},
-    {"_dodgr_rcpp_get_component_vector", (DL_FUNC) &_dodgr_rcpp_get_component_vector, 1},
+    {"_dodgr_rcpp_get_component_vector", (DL_FUNC) &_dodgr_rcpp_get_component_vector, 2},
     {"_dodgr_rcpp_unique_rownames", (DL_FUNC) &_dodgr_rcpp_unique_rownames, 3},
     {"_dodgr_rcpp_points_index_par", (DL_FUNC) &_dodgr_rcpp_points_index_par, 2},
     {"_dodgr_rcpp_points_to_edges_par", (DL_FUNC) &_dodgr_rcpp_points_to_edges_par, 2},

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -120,7 +120,7 @@ bool graph::graph_from_df (const Rcpp::DataFrame &gr, vertex_map_t &vm,
 //' identify_graph_components
 //'
 //' Identify initial graph components for each **vertex**
-//' Identification for edges is subsequently perrformed with 
+//' Identification for edges is subsequently performed with 
 //' \code{rcpp_get_component_vector}.
 //'
 //' @param v unordered_map <vertex_id_t, vertex_t>
@@ -177,6 +177,112 @@ size_t graph::identify_graph_components (vertex_map_t &v,
     return static_cast <size_t> (largest_id);
 }
 
+//' strong_connect
+//'
+//' Helper function for applying Tarjan's algroithm to identify
+//' strong components recursively
+//'
+//' @param vt id of vertex currently being evaluated
+//' @param v unordered_map <vertex_id_t, vertex_t>
+//' @param com component map from each vertex to component numbers
+//' @param index_map map from each vertex to index number
+//' @param lowlink_map map from each vertex to lowlink number
+//' @param on_stack set of all vertices currently on stack
+//' @param s stack used to execute algorithm
+//' @param index used to execute algoritm
+//' @param compnum the current component number
+//' @noRd
+void graph::strong_connect(vertex_id_t vt,
+    vertex_map_t &v,
+    std::unordered_map <vertex_id_t, size_t> &com,
+    std::unordered_map <vertex_id_t, size_t> &index_map,
+    std::unordered_map <vertex_id_t, size_t> &lowlink_map,
+    std::unordered_set <vertex_id_t> &on_stack,
+    std::stack <vertex_id_t> &s,
+    size_t &index,
+    size_t &compnum)
+{
+
+    Rcpp::checkUserInterrupt ();
+
+    index_map [vt] = index;
+    lowlink_map [vt] = index;
+    index++;
+    s.push (vt);
+    on_stack.insert (vt);
+
+    vertex_t vtx = v.find (vt)->second;
+    std::unordered_set<vertex_id_t> nbs = vtx.get_out_neighbours ();
+
+    for (auto nvtx : nbs)
+    {
+        if (index_map.find (nvtx) == index_map.end ())
+        {
+            strong_connect (nvtx, v, com, index_map, lowlink_map, on_stack, s, index, compnum);
+            lowlink_map [vt] = std::min (lowlink_map [vt], lowlink_map [nvtx]);
+        }
+        else if (on_stack.find (nvtx) != on_stack.end ())
+        {
+            lowlink_map [vt] = std::min (lowlink_map [vt], index_map [nvtx]);
+        }
+    }
+
+    if (lowlink_map [vt] == index_map [vt])
+    {
+        vertex_id_t w;
+        do
+        {
+            w = s.top ();
+            s.pop ();
+            on_stack.erase (w);
+            com [w] = compnum;
+        } while (w != vt);
+        compnum++;
+    }
+}
+
+//' identify_graph_strong_components
+//'
+//' Identify initial graph strong components for each **vertex**
+//' Identification for edges is subsequently performed with 
+//' \code{rcpp_get_component_vector}.
+//'
+//' @param v unordered_map <vertex_id_t, vertex_t>
+//' @param com component map from each vertex to component numbers
+//' @noRd
+size_t graph::identify_graph_strong_components (vertex_map_t &v,
+        std::unordered_map <vertex_id_t, size_t> &com)
+{
+    com.clear ();
+
+    size_t index = 0;
+    size_t compnum = 0;
+
+    std::unordered_map <vertex_id_t, size_t> index_map;
+    std::unordered_map <vertex_id_t, size_t> lowlink_map;
+    std::unordered_set <vertex_id_t> on_stack;
+    std::stack <vertex_id_t> s;
+
+    for (auto it : v)
+    {
+        vertex_id_t vt = it.first;
+        if (index_map.find (vt) == index_map.end ())
+            strong_connect (vt, v, com, index_map, lowlink_map, on_stack, s, index, compnum);
+    }
+
+    long int largest_id = 0;
+    if (compnum > 0)
+    {
+        std::vector <size_t> comp_sizes (compnum + 1, 0);
+        for (auto c: com)
+            comp_sizes [c.second]++;
+        auto maxi = std::max_element (comp_sizes.begin (), comp_sizes.end ());
+
+        largest_id = std::distance (comp_sizes.begin (), maxi);
+    }
+
+    return static_cast <size_t> (largest_id);
+}
 
 //' rcpp_get_component_vector
 //'
@@ -185,11 +291,14 @@ size_t graph::identify_graph_components (vertex_map_t &v,
 //' @param graph graph to be processed; stripped down and standardised to five
 //' columns
 //'
+//' @param strong A Boolean flag to indicate whether components should be strong,
+//' i.e. its vertices connected bidirectionally. Defaults to FALSE.
+//'
 //' @return Two vectors: one of edge IDs and one of corresponding component
 //' numbers
 //' @noRd
 // [[Rcpp::export]]
-Rcpp::List rcpp_get_component_vector (const Rcpp::DataFrame &graph)
+Rcpp::List rcpp_get_component_vector (const Rcpp::DataFrame &graph, bool strong = false)
 {
     vertex_map_t vertices;
     edge_map_t edge_map;
@@ -199,18 +308,21 @@ Rcpp::List rcpp_get_component_vector (const Rcpp::DataFrame &graph)
     has_times = false; // rm unused variable warning
 
     std::unordered_map <vertex_id_t, size_t> components;
-    size_t largest_component =
-        graph::identify_graph_components (vertices, components);
+    size_t largest_component;
+
+    if (strong)
+        largest_component = graph::identify_graph_strong_components (vertices, components);
+    else
+        largest_component = graph::identify_graph_components (vertices, components);
+
     largest_component++; // suppress unused variable warning
 
     // Then map component numbers of vertices onto edges
     std::unordered_map <edge_id_t, size_t> comp_nums;
-    for (auto ve: vert2edge_map)
+    for (auto e : edge_map)
     {
-        vertex_id_t vi = ve.first;
-        std::unordered_set <edge_id_t> edges = ve.second;
-        for (edge_id_t e: edges)
-            comp_nums.emplace (e, components.find (vi)->second);
+        vertex_id_t vi = e.second.get_from_vertex ();
+        comp_nums.emplace (e.first, components.find(vi)->second);
     }
 
     Rcpp::StringVector edge_id (comp_nums.size ());

--- a/src/graph.h
+++ b/src/graph.h
@@ -8,6 +8,7 @@
 #include <string> // stoi
 #include <cmath> // round
 #include <math.h> // isnan
+#include <stack>
 
 const float INFINITE_FLOAT =  std::numeric_limits <float>::max ();
 const double INFINITE_DOUBLE =  std::numeric_limits <double>::max ();
@@ -146,9 +147,23 @@ bool graph_from_df (const Rcpp::DataFrame &gr, vertex_map_t &vm,
 size_t identify_graph_components (vertex_map_t &v,
         std::unordered_map <vertex_id_t, size_t> &com);
 
+size_t identify_graph_strong_components (vertex_map_t &v,
+        std::unordered_map <vertex_id_t, size_t> &com);
+
+void strong_connect (vertex_id_t vt,
+    vertex_map_t &v,
+    std::unordered_map <vertex_id_t, size_t> &com,
+    std::unordered_map <vertex_id_t, size_t> &index_map,
+    std::unordered_map <vertex_id_t, size_t> &lowlink_map,
+    std::unordered_set <vertex_id_t> &on_stack,
+    std::stack <vertex_id_t> &s,
+    size_t &index,
+    size_t &compnum);
+
+
 } // end namespace graph
 
-Rcpp::List rcpp_get_component_vector (const Rcpp::DataFrame &graph);
+Rcpp::List rcpp_get_component_vector (const Rcpp::DataFrame &graph, bool strong);
 
 Rcpp::DataFrame rcpp_unique_rownames (Rcpp::DataFrame xyfrom, Rcpp::DataFrame xyto,
         const int precision);


### PR DESCRIPTION
This change adds additional functionality to the dodgr_components() function, where a new Boolean flag `strong` will cause the function to find the strong components of a directed graph. Thus, the partition of the graph into maximal subgraphs in which, for each pair of vertices i and j, paths exist both from i to j and from j to i. This is discussed further in Issue #322 .

The main addition is to `graph.cpp`, in which new functions `identify_graph_strong_components` and its recursive helper `strong_connect` implement [Tarjan's strongly connected components algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm).

The format of the output of this algorithm, in comparison to the weak version, necessitated some minor adjustments to higher-level functions. 

Firstly, within `rcpp_get_component_vector`, the mapping of component numbers to edges has been adjusted such that an edge is always assigned the component of its start node.
```
for (auto e : edge_map)
{
    vertex_id_t vi = e.second.get_from_vertex ();
    comp_nums.emplace (e.first, components.find(vi)->second);
}
```
For the weak algorithm, this won't have any effect, as both start and end node are necessarily in the same component. However, for the strong algorithm this is not always the case, so edges that cross between strong components are (arbitrarily) assigned consistently to that of the start node.

Secondly, within the R function `dodgr_components`, the assignment of component numbers in descending order is adjusted to use the frequencies when sorting.
```
freqs <- table (component)
sorted_components <- names (freqs) [order (freqs, decreasing = TRUE)]
graph$component <- match (as.character (component), sorted_components)
```
As the strong algorithm may result in components with no edges (i.e. individual nodes with no outbound edges), some numbers will be missed in the component table, resulting in an incorrect assignment of components. Using frequencies resolves this error.

Other changes to graph-functions.R, graph.h and graph.cpp were to insert the Boolean flag `strong` to the necessary functions, ensuring that it defaults to `FALSE` so as to be compatible with existing code.
